### PR TITLE
Fix Tracker.get() method testing RegExp against itself rather then testing url with it

### DIFF
--- a/index.js
+++ b/index.js
@@ -155,7 +155,7 @@ class Tracker {
    */
   get(method, url) {
     function getElem (element, index, array) {
-      let matchedUrl = element.url instanceof RegExp ? element.url.test(element.url) : element.url === url;
+      let matchedUrl = element.url instanceof RegExp ? element.url.test(url) : element.url === url;
       let matchedMethod;
 
       if (element.config) {

--- a/test.js
+++ b/test.js
@@ -187,6 +187,16 @@ describe('moxios', function () {
         notEqual(request, undefined)
       })
 
+      it('should find single stub by url using RegExp', function () {
+        moxios.stubOnce('GET', /^\/users\/\d+$/ , {
+          status: 200
+        })
+
+        let request = moxios.stubs.get('GET', '/users/12345')
+
+        notEqual(request, undefined)
+      })
+
       it('should remove a single stub by method', function () {
         moxios.stubOnce('PUT', '/users/12346', {
           status: 204


### PR DESCRIPTION
This should fix issue #57 