### PR TITLE
Fixes a bug when method is undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -163,7 +163,7 @@ class Tracker {
         matchedMethod = method.toLowerCase() === element.config.method.toLowerCase();
       } else {
         // stub tracking
-        matchedMethod = method.toLowerCase() === element.method.toLowerCase();
+        matchedMethod = element.method && method.toLowerCase() === element.method.toLowerCase();
       }
 
       if (matchedUrl && matchedMethod) {


### PR DESCRIPTION
This PR fixes a bug when there is no method defined when mocking. 